### PR TITLE
Add modal-based FullCalendar event management

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,41 +7,20 @@
   <link href="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/main.min.css" rel="stylesheet">
   <style>
     * { box-sizing: border-box; }
-    body {
-      margin: 0;
-      font-family: Arial, sans-serif;
-      background: #f9f9f9;
-    }
-    header {
-      display: flex;
-      align-items: center;
-      padding: 10px 20px;
-      background-color: #003049;
-      color: white;
-    }
-    header img {
-      height: 40px;
-      margin-right: 15px;
-    }
-    h1 {
-      font-size: 1.5rem;
-      margin: 0;
-    }
-    main {
-      padding: 20px;
-    }
-    #calendar {
-      max-width: 900px;
-      margin: 0 auto;
-      background: white;
-      padding: 10px;
-      border-radius: 6px;
-      box-shadow: 0 2px 6px rgba(0,0,0,0.1);
-    }
-    .fc-event-title,
-    .fc-event-location {
-      font-size: 0.85em;
-    }
+    body { margin: 0; font-family: Arial, sans-serif; background: #f9f9f9; }
+    header { display: flex; align-items: center; padding: 10px 20px; background-color: #003049; color: white; }
+    header img { height: 40px; margin-right: 15px; }
+    h1 { font-size: 1.5rem; margin: 0; }
+    main { padding: 20px; }
+    #calendar { max-width: 900px; margin: 0 auto; background: white; padding: 10px; border-radius: 6px; box-shadow: 0 2px 6px rgba(0,0,0,0.1); }
+    .fc-event-title, .fc-event-location { font-size: 0.85em; }
+    .modal { position: fixed; top: 0; left: 0; width: 100%; height: 100%; background: rgba(0,0,0,0.5); display: flex; align-items: center; justify-content: center; }
+    .hidden { display: none; }
+    .modal-content { background: white; padding: 20px; border-radius: 6px; width: 280px; }
+    .modal-content label { display: block; margin-bottom: 10px; }
+    .modal-content input, .modal-content select { width: 100%; padding: 5px; }
+    .buttons { text-align: right; margin-top: 10px; }
+    .buttons button { margin-left: 5px; }
   </style>
 </head>
 <body>
@@ -52,73 +31,95 @@
 <main>
   <div id="calendar"></div>
 </main>
+<div id="modal" class="modal hidden">
+  <form id="event-form" class="modal-content">
+    <h2 id="form-title">Add Session</h2>
+    <input type="hidden" id="event-id">
+    <label>Session Title
+      <input type="text" id="session-title" required>
+    </label>
+    <label>Start Date &amp; Time
+      <input type="datetime-local" id="session-start" required>
+    </label>
+    <label>Location
+      <input type="text" id="session-location">
+    </label>
+    <label>State
+      <select id="session-state">
+        <option value="QLD">QLD</option>
+        <option value="VIC">VIC</option>
+        <option value="NSW">NSW</option>
+        <option value="ACT">ACT</option>
+      </select>
+    </label>
+    <div class="buttons">
+      <button type="submit">Save</button>
+      <button type="button" id="delete-btn">Delete</button>
+      <button type="button" id="cancel-btn">Cancel</button>
+    </div>
+  </form>
+</div>
 <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.8/index.global.min.js"></script>
 <script>
   document.addEventListener('DOMContentLoaded', function () {
-    const stateColors = { QLD: 'orange', VIC: 'blue' };
-
-    function loadEvents() {
-      const stored = localStorage.getItem('calendarEvents');
-      if (stored) {
-        return JSON.parse(stored);
-      }
-      return [{
-        id: String(Date.now()),
-        title: 'Sample Session',
-        start: new Date().toISOString().split('T')[0] + 'T09:00',
-        end: new Date(Date.now() + 60*60*1000).toISOString().slice(0,16),
-        extendedProps: { location: 'Brisbane', state: 'QLD' },
-        color: stateColors['QLD']
-      }];
-    }
-
-    function saveEvents(events) {
-      localStorage.setItem('calendarEvents', JSON.stringify(events));
-    }
-
-    function toObject(event) {
-      return {
-        id: event.id,
-        title: event.title,
-        start: event.startStr,
-        end: event.endStr,
-        extendedProps: {
-          location: event.extendedProps.location,
-          state: event.extendedProps.state
-        },
-        color: event.backgroundColor
-      };
-    }
-
-    function getColor(state) {
-      return stateColors[state] || '#3788d8';
-    }
-
-    function promptForEvent(opts) {
-      const title = prompt('Session title:', opts.title || '');
-      if (!title) return null;
-      const startTime = prompt('Start time (HH:MM, 24h):', opts.startTime || '09:00');
-      if (!startTime) return null;
-      const duration = parseFloat(prompt('Duration in hours:', opts.duration || '1')) || 1;
-      const location = prompt('Location:', opts.location || '') || '';
-      const state = prompt('State (e.g., QLD, VIC):', opts.state || '') || '';
-
-      const startDateStr = (opts.date || opts.startDate) + 'T' + startTime;
-      const startDate = new Date(startDateStr);
-      const endDate = new Date(startDate.getTime() + duration * 60 * 60 * 1000);
-
-      return {
-        id: opts.id || String(Date.now()),
-        title: title,
-        start: startDate.toISOString().slice(0,16),
-        end: endDate.toISOString().slice(0,16),
-        extendedProps: { location: location, state: state },
-        color: getColor(state)
-      };
-    }
+    const stateColors = { QLD: 'orange', VIC: 'blue', NSW: 'green', ACT: 'purple' };
 
     const calendarEl = document.getElementById('calendar');
-    const events = loadEvents();
+    const modal = document.getElementById('modal');
+    const form = document.getElementById('event-form');
+    const titleInput = document.getElementById('session-title');
+    const startInput = document.getElementById('session-start');
+    const locationInput = document.getElementById('session-location');
+    const stateInput = document.getElementById('session-state');
+    const deleteBtn = document.getElementById('delete-btn');
+    const cancelBtn = document.getElementById('cancel-btn');
+    const formTitle = document.getElementById('form-title');
+
+    let editingEvent = null;
+
+    function loadEvents() {
+      const stored = localStorage.getItem('sessions');
+      return stored ? JSON.parse(stored) : [];
+    }
+
+    function saveAll() {
+      const data = calendar.getEvents().map(e => ({
+        id: e.id,
+        title: e.title,
+        start: e.startStr,
+        end: e.endStr,
+        extendedProps: {
+          location: e.extendedProps.location,
+          state: e.extendedProps.state
+        },
+        color: e.backgroundColor
+      }));
+      localStorage.setItem('sessions', JSON.stringify(data));
+    }
+
+    function openModal(data) {
+      form.reset();
+      deleteBtn.style.display = 'none';
+      formTitle.textContent = 'Add Session';
+      editingEvent = null;
+      if (data instanceof FullCalendar.EventApi) {
+        editingEvent = data;
+        titleInput.value = data.title;
+        startInput.value = data.startStr.slice(0,16);
+        locationInput.value = data.extendedProps.location || '';
+        stateInput.value = data.extendedProps.state || 'QLD';
+        deleteBtn.style.display = 'inline-block';
+        formTitle.textContent = 'Edit Session';
+      } else if (data && data.start) {
+        startInput.value = data.start;
+      }
+      modal.classList.remove('hidden');
+    }
+
+    function closeModal() {
+      modal.classList.add('hidden');
+      editingEvent = null;
+    }
 
     const calendar = new FullCalendar.Calendar(calendarEl, {
       initialView: 'dayGridMonth',
@@ -129,7 +130,7 @@
       },
       selectable: true,
       editable: true,
-      events: events,
+      events: loadEvents(),
       eventContent: function(arg) {
         const title = document.createElement('div');
         title.textContent = arg.event.title;
@@ -138,46 +139,52 @@
         info.textContent = arg.timeText + (loc ? ' - ' + loc : '');
         return { domNodes: [title, info] };
       },
-      dateClick: function(info) {
-        const newEvt = promptForEvent({ date: info.dateStr });
-        if (newEvt) {
-          calendar.addEvent(newEvt);
-          saveEvents(calendar.getEvents().map(toObject));
-        }
+      dateClick(info) {
+        openModal({ start: info.dateStr + 'T09:00' });
       },
-      eventClick: function(info) {
-        const action = prompt("Type 'edit' to edit or 'delete' to remove this session:");
-        if (action === 'delete') {
-          if (confirm('Delete this session?')) {
-            info.event.remove();
-            saveEvents(calendar.getEvents().map(toObject));
-          }
-        } else if (action === 'edit') {
-          const edited = promptForEvent({
-            id: info.event.id,
-            date: info.event.startStr.slice(0,10),
-            startTime: info.event.startStr.slice(11,16),
-            duration: ((info.event.end - info.event.start) / 3600000) || 1,
-            title: info.event.title,
-            location: info.event.extendedProps.location,
-            state: info.event.extendedProps.state
-          });
-          if (edited) {
-            info.event.remove();
-            calendar.addEvent(edited);
-            saveEvents(calendar.getEvents().map(toObject));
-          }
-        }
+      eventClick(info) {
+        openModal(info.event);
       },
-      eventDrop: function() {
-        saveEvents(calendar.getEvents().map(toObject));
-      },
-      eventResize: function() {
-        saveEvents(calendar.getEvents().map(toObject));
-      }
+      eventDrop: saveAll,
+      eventResize: saveAll
     });
 
     calendar.render();
+
+    form.addEventListener('submit', function(e) {
+      e.preventDefault();
+      const startVal = startInput.value;
+      const endVal = new Date(new Date(startVal).getTime() + 60*60*1000).toISOString().slice(0,16);
+      const state = stateInput.value;
+      const eventData = {
+        id: editingEvent ? editingEvent.id : String(Date.now()),
+        title: titleInput.value,
+        start: startVal,
+        end: endVal,
+        extendedProps: {
+          location: locationInput.value,
+          state: state
+        },
+        color: stateColors[state] || '#3788d8'
+      };
+
+      if (editingEvent) {
+        editingEvent.remove();
+      }
+      calendar.addEvent(eventData);
+      saveAll();
+      closeModal();
+    });
+
+    cancelBtn.addEventListener('click', closeModal);
+
+    deleteBtn.addEventListener('click', function() {
+      if (editingEvent) {
+        editingEvent.remove();
+        saveAll();
+        closeModal();
+      }
+    });
   });
 </script>
 </body>


### PR DESCRIPTION
## Summary
- implement all calendar logic in single HTML file
- add modal form for creating, editing and deleting events
- persist events in `localStorage`
- color sessions by state

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6862e2892f888325bb44bdc54baaf9d8